### PR TITLE
Ledger changes

### DIFF
--- a/kin-base-test/kin-base-test.csproj
+++ b/kin-base-test/kin-base-test.csproj
@@ -237,5 +237,8 @@
     <None Update="testdata\operationManageBuyOffer.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="testdata\transactionResultChanges.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/kin-base-test/responses/TransactionDeserializerTest.cs
+++ b/kin-base-test/responses/TransactionDeserializerTest.cs
@@ -2,6 +2,7 @@
 
 
 using System.IO;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Kin.Base;
@@ -78,6 +79,33 @@ namespace kin_base_test.responses
 
             Assert.IsFalse(transaction.Successful);
             Assert.IsTrue(transaction.Memo is MemoNone);
+        }
+
+        [TestMethod]
+        public void TestGetChanges()
+        {
+            var json = File.ReadAllText(Path.Combine("testdata", "transactionResultChanges.json"));
+            var transaction = JsonSingleton.GetInstance<TransactionResponse>(json);
+
+            // Transaction which created an account, and payed 10 kin to another
+            List<LedgerEntryChanges> changes = transaction.GetLedgerChanges();
+            Assert.AreEqual(changes.Count, 2); // Two operations
+            Assert.AreEqual(changes[0].LedgerEntryUpdates.Length, 1);
+            var accountEntry = (AccountLedgerEntryChange) changes[0].LedgerEntryUpdates[0];
+            Assert.AreEqual(accountEntry.LastModifiedLedgerSeq, 4145508);
+            Assert.AreEqual(accountEntry.Balance, "74327872");
+            Assert.AreEqual(accountEntry.AccountId.AccountId, "GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX");
+
+            Assert.AreEqual(changes[1].LedgerEntryUpdates.Length, 2);
+            var accountEntry2 = (AccountLedgerEntryChange) changes[1].LedgerEntryUpdates[0];
+            Assert.AreEqual(accountEntry2.LastModifiedLedgerSeq, 4145508);
+            Assert.AreEqual(accountEntry2.Balance, "74327862");
+            Assert.AreEqual(accountEntry2.AccountId.AccountId, "GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX");
+
+            var accountEntry3 = (AccountLedgerEntryChange) changes[1].LedgerEntryUpdates[0];
+            Assert.AreEqual(accountEntry3.LastModifiedLedgerSeq, 4145508);
+            Assert.AreEqual(accountEntry3.Balance, "10");
+            Assert.AreEqual(accountEntry3.AccountId.AccountId, "GBGAUR5WGQF3UGGPT2FSWLBCA4WDWKVZOHXWVG5RVQHY4EKJ6SP4SG5G");
         }
     }
 }

--- a/kin-base-test/responses/TransactionDeserializerTest.cs
+++ b/kin-base-test/responses/TransactionDeserializerTest.cs
@@ -92,18 +92,18 @@ namespace kin_base_test.responses
             Assert.AreEqual(changes.Count, 2); // Two operations
             Assert.AreEqual(changes[0].LedgerEntryUpdates.Length, 1);
             var accountEntry = (AccountLedgerEntryChange) changes[0].LedgerEntryUpdates[0];
-            Assert.AreEqual(accountEntry.LastModifiedLedgerSeq, 4145508);
+            Assert.AreEqual(accountEntry.LastModifiedLedgerSeq, 4145508U);
             Assert.AreEqual(accountEntry.Balance, "74327872");
             Assert.AreEqual(accountEntry.AccountId.AccountId, "GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX");
 
             Assert.AreEqual(changes[1].LedgerEntryUpdates.Length, 2);
             var accountEntry2 = (AccountLedgerEntryChange) changes[1].LedgerEntryUpdates[0];
-            Assert.AreEqual(accountEntry2.LastModifiedLedgerSeq, 4145508);
+            Assert.AreEqual(accountEntry2.LastModifiedLedgerSeq, 4145508U);
             Assert.AreEqual(accountEntry2.Balance, "74327862");
             Assert.AreEqual(accountEntry2.AccountId.AccountId, "GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX");
 
             var accountEntry3 = (AccountLedgerEntryChange) changes[1].LedgerEntryUpdates[0];
-            Assert.AreEqual(accountEntry3.LastModifiedLedgerSeq, 4145508);
+            Assert.AreEqual(accountEntry3.LastModifiedLedgerSeq, 4145508U);
             Assert.AreEqual(accountEntry3.Balance, "10");
             Assert.AreEqual(accountEntry3.AccountId.AccountId, "GBGAUR5WGQF3UGGPT2FSWLBCA4WDWKVZOHXWVG5RVQHY4EKJ6SP4SG5G");
         }

--- a/kin-base-test/responses/TransactionDeserializerTest.cs
+++ b/kin-base-test/responses/TransactionDeserializerTest.cs
@@ -102,7 +102,7 @@ namespace kin_base_test.responses
             Assert.AreEqual(accountEntry2.Balance, "74327862");
             Assert.AreEqual(accountEntry2.AccountId.AccountId, "GA5VKONC2ABAHER37Q6WZ7JLBEQ2RENLU2GVP2K2E2HAJT2T6CNPZ7QX");
 
-            var accountEntry3 = (AccountLedgerEntryChange) changes[1].LedgerEntryUpdates[0];
+            var accountEntry3 = (AccountLedgerEntryChange) changes[1].LedgerEntryUpdates[1];
             Assert.AreEqual(accountEntry3.LastModifiedLedgerSeq, 4145508U);
             Assert.AreEqual(accountEntry3.Balance, "10");
             Assert.AreEqual(accountEntry3.AccountId.AccountId, "GBGAUR5WGQF3UGGPT2FSWLBCA4WDWKVZOHXWVG5RVQHY4EKJ6SP4SG5G");

--- a/kin-base-test/testdata/transactionResultChanges.json
+++ b/kin-base-test/testdata/transactionResultChanges.json
@@ -1,0 +1,47 @@
+{
+    "memo": "1-mgsr-",
+    "_links": {
+      "self": {
+        "href": "https://horizon-block-explorer.kininfrastructure.com/transactions/1fbdf1e300460eaea48c35d173f6aab34999c9c9efd2e3b30e2f41903d72cdc7"
+      },
+      "account": {
+        "href": "https://horizon-block-explorer.kininfrastructure.com/accounts/GC3LQHI6UQ2Z35X4HX6RTMMYINJHMLF4XMZAQGMRDFYFPKE6W5SPGVJB"
+      },
+      "ledger": {
+        "href": "https://horizon-block-explorer.kininfrastructure.com/ledgers/4145508"
+      },
+      "operations": {
+        "href": "https://horizon-block-explorer.kininfrastructure.com/transactions/1fbdf1e300460eaea48c35d173f6aab34999c9c9efd2e3b30e2f41903d72cdc7/operations{?cursor,limit,order}",
+        "templated": true
+      },
+      "effects": {
+        "href": "https://horizon-block-explorer.kininfrastructure.com/transactions/1fbdf1e300460eaea48c35d173f6aab34999c9c9efd2e3b30e2f41903d72cdc7/effects{?cursor,limit,order}",
+        "templated": true
+      },
+      "precedes": {
+        "href": "https://horizon-block-explorer.kininfrastructure.com/transactions?order=asc\u0026cursor=17804821285482496"
+      },
+      "succeeds": {
+        "href": "https://horizon-block-explorer.kininfrastructure.com/transactions?order=desc\u0026cursor=17804821285482496"
+      }
+    },
+    "id": "1fbdf1e300460eaea48c35d173f6aab34999c9c9efd2e3b30e2f41903d72cdc7",
+    "paging_token": "17804821285482496",
+    "hash": "1fbdf1e300460eaea48c35d173f6aab34999c9c9efd2e3b30e2f41903d72cdc7",
+    "ledger": 4145508,
+    "created_at": "2019-09-12T05:20:21Z",
+    "source_account": "GC3LQHI6UQ2Z35X4HX6RTMMYINJHMLF4XMZAQGMRDFYFPKE6W5SPGVJB",
+    "source_account_sequence": "2505881488988890",
+    "fee_paid": 0,
+    "operation_count": 2,
+    "envelope_xdr": "AAAAALa4HR6kNZ32/D39GbGYQ1J2LLy7MggZkRlwV6iet2TzAAAAAAAI5xYAABraAAAAAAAAAAEAAAAHMS1tZ3NyLQAAAAACAAAAAQAAAAA7VTmi0AIDkjv8PWz9KwkhqJGrpo1X6VomjgTPU/Ca/AAAAAAAAAAAEw3KOfRYoOJL+0pkv8zDtSAL2g8bChq7GZADBcDAXVQAAAAAAAAAAAAAAAEAAAAAO1U5otACA5I7/D1s/SsJIaiRq6aNV+laJo4Ez1PwmvwAAAABAAAAAEwKR7Y0C7oYz56LKywiByw7Krlx72qbsawPjhFJ9J/JAAAAAAAAAAAAD0JAAAAAAAAAAAKet2TzAAAAQIBL30cipHI2/YAgniL3IAxu6o0RgTco5wpy/9M49AaEpNiecatQgwlxZhNn9eGxKf54PhHnQiKuypbMRkU7AwxT8Jr8AAAAQJCymql4gKR1/mBBOATCCo0DKZxRNvkf3lydBBhFnEeUrlRt+ApuiNod7Rm0RXS662jRAT754x/e6uaA05gi8QI=",
+    "result_xdr": "AAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAA=",
+    "result_meta_xdr": "AAAAAAAAAAIAAAADAAAAAAA/QWQAAAAAAAAAABMNyjn0WKDiS/tKZL/Mw7UgC9oPGwoauxmQAwXAwF1UAAAAAAAAAAAAP0FkAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwA/QAIAAAAAAAAAADtVOaLQAgOSO/w9bP0rCSGokaumjVfpWiaOBM9T8Jr8AAAGwpSkCAAACObrAAAADQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQA/QWQAAAAAAAAAADtVOaLQAgOSO/w9bP0rCSGokaumjVfpWiaOBM9T8Jr8AAAGwpSkCAAACObrAAAADQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAABAAAAAMAP0FkAAAAAAAAAAA7VTmi0AIDkjv8PWz9KwkhqJGrpo1X6VomjgTPU/Ca/AAABsKUpAgAAAjm6wAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAP0FkAAAAAAAAAAA7VTmi0AIDkjv8PWz9KwkhqJGrpo1X6VomjgTPU/Ca/AAABsKUlMXAAAjm6wAAAA0AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAHuhaAAAAAAAAAABMCke2NAu6GM+eiyssIgcsOyq5ce9qm7GsD44RSfSfyQAAAAAAAAAAAB7oWgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAP0FkAAAAAAAAAABMCke2NAu6GM+eiyssIgcsOyq5ce9qm7GsD44RSfSfyQAAAAAAD0JAAB7oWgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+    "fee_meta_xdr": "AAAAAgAAAAMAPz5tAAAAAAAAAAC2uB0epDWd9vw9/RmxmENSdiy8uzIIGZEZcFeonrdk8wAAAAAAAAAAAAjnFgAAGtkAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAP0FkAAAAAAAAAAC2uB0epDWd9vw9/RmxmENSdiy8uzIIGZEZcFeonrdk8wAAAAAAAAAAAAjnFgAAGtoAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+    "memo_type": "text",
+    "signatures": [
+      "gEvfRyKkcjb9gCCeIvcgDG7qjRGBNyjnCnL/0zj0BoSk2J5xq1CDCXFmE2f14bEp/ng+EedCIq7KlsxGRTsDDA==",
+      "kLKaqXiApHX+YEE4BMIKjQMpnFE2+R/eXJ0EGEWcR5SuVG34Cm6I2h3tGbRFdLrraNEBPvnjH97q5oDTmCLxAg=="
+    ]
+  }
+  

--- a/kin-base/AccountLedgerEntryChange.cs
+++ b/kin-base/AccountLedgerEntryChange.cs
@@ -1,0 +1,20 @@
+using Kin.Base.xdr;
+
+namespace Kin.Base
+{
+    public class AccountLedgerEntryChange : LedgerEntryChange
+    {
+        public KeyPair AccountId { get; private set;}
+        public string Balance { get; private set;}
+
+        AccountLedgerEntryChange() {}
+
+        public static AccountLedgerEntryChange FromXdr(AccountEntry xdr)
+        {
+            AccountLedgerEntryChange entry = new AccountLedgerEntryChange();
+            entry.AccountId = KeyPair.FromXdrPublicKey(xdr.AccountID.InnerValue);
+            entry.Balance = Operation.FromXdrAmount(xdr.Balance.InnerValue);
+            return entry;
+        }
+    }
+}

--- a/kin-base/LedgerEntryChange.cs
+++ b/kin-base/LedgerEntryChange.cs
@@ -1,0 +1,32 @@
+using System;
+using Kin.Base.xdr;
+
+namespace Kin.Base
+{
+    public class LedgerEntryChange
+    {
+        public UInt32 LastModifiedLedgerSeq { get; private set;}
+
+        protected LedgerEntryChange() {}
+
+        public static LedgerEntryChange FromXdr(LedgerEntry xdr)
+        {
+            LedgerEntryChange entryChange = null;
+            switch (xdr.Data.Discriminant.InnerValue)
+            {
+                case LedgerEntryType.LedgerEntryTypeEnum.ACCOUNT:
+                    entryChange = AccountLedgerEntryChange.FromXdr(xdr.Data.Account);
+                    entryChange.LastModifiedLedgerSeq = (UInt32) xdr.LastModifiedLedgerSeq.InnerValue;
+                    break;
+                case LedgerEntryType.LedgerEntryTypeEnum.DATA:
+                case LedgerEntryType.LedgerEntryTypeEnum.TRUSTLINE:
+                case LedgerEntryType.LedgerEntryTypeEnum.OFFER:
+                    break;
+                default:
+                    throw new ArgumentException("The provided xdr's entry type is invalid");
+            }
+
+            return entryChange;
+        }
+    }
+}

--- a/kin-base/LedgerEntryChanges.cs
+++ b/kin-base/LedgerEntryChanges.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using static Kin.Base.xdr.LedgerEntryChangeType.LedgerEntryChangeTypeEnum;
+
+namespace Kin.Base
+{
+    public class LedgerEntryChanges
+    {
+
+        public LedgerEntryChange[] LedgerEntryUpdates { get; private set; }
+        LedgerEntryChanges() { }
+
+        public static LedgerEntryChanges FromXdr(Kin.Base.xdr.LedgerEntryChanges xdr)
+        {
+            LedgerEntryChanges changes = new LedgerEntryChanges();
+            List<LedgerEntryChange> updates = new List<LedgerEntryChange>();
+            foreach (var change in xdr.InnerValue)
+            {
+                switch (change.Discriminant.InnerValue)
+                {
+                    case LEDGER_ENTRY_UPDATED:
+                        var result = LedgerEntryChange.FromXdr(change.Updated);
+                        if (result != null)
+                        {
+                            updates.Add(result);
+                        };
+                        break;
+                    case LEDGER_ENTRY_REMOVED:
+                    case LEDGER_ENTRY_CREATED:
+                    case LEDGER_ENTRY_STATE:
+                        break;
+                    default:
+                        throw new ArgumentException("Invalid LedgerEntryType");
+                }
+            }
+
+            changes.LedgerEntryUpdates = updates.ToArray();
+            return changes;
+        }
+    }
+}

--- a/kin-base/kin-base.csproj
+++ b/kin-base/kin-base.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/kin-base/responses/TransactionResponse.cs
+++ b/kin-base/responses/TransactionResponse.cs
@@ -3,10 +3,13 @@
 
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Kin.Base.responses.effects;
 using Kin.Base.responses.operations;
 using Kin.Base.responses.page;
+
+using Kin.Base.xdr;
 
 namespace Kin.Base.responses
 {
@@ -126,6 +129,24 @@ namespace Kin.Base.responses
             ResultMetaXdr = resultMetaXdr;
             Memo = memo;
             Links = links;
+        }
+
+        public List<LedgerEntryChanges> GetLedgerChanges()
+        {
+            TransactionMeta transactionMeta = this.ExtractTransactionMeta();
+            OperationMeta[] operationMetas = transactionMeta.Operations;
+            List<LedgerEntryChanges> changeList = new List<LedgerEntryChanges>();
+            foreach (var op in operationMetas)
+            {
+                changeList.Add(LedgerEntryChanges.FromXdr(op.Changes));
+            }
+            return changeList;
+        }
+
+        private TransactionMeta ExtractTransactionMeta()
+        {
+            XdrDataInputStream inputStream = new XdrDataInputStream(Convert.FromBase64String(this.ResultMetaXdr));
+            return TransactionMeta.Decode(inputStream);
         }
 
         ///


### PR DESCRIPTION
This is basically a port of the changes we made to kin-base-android to get LedgerEntryChanges from a transaction response.

I left most stuff the same with small changes (for example not parsing trustlines since its unnecessary now)